### PR TITLE
Disable silkyevcam patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ ament_vendor(openeb_vendor
   VCS_URL https://github.com/prophesee-ai/openeb.git
   VCS_VERSION 5.0.0
   GLOBAL_HOOK
-  PATCHES patches
+#  PATCHES patches
   CMAKE_ARGS
   -DCOMPILE_PLAYER:BOOL=OFF
   -DCOMPILE_PYTHON3_BINDINGS:BOOL=OFF

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Wrapper package to build the [Prophesee OpenEB](https://github.com/prophesee-ai/openeb)
 library (Metavision SDK) on the ROS2 build farm.
 
-This package also contains a patch to build the [SilkyEVCam
-plugin](https://centuryarks.com/en/download/) from source.
+Note:
+The patch to build the [SilkyEVCam plugin](https://centuryarks.com/en/download/) has been suspended for
+now since it disables the Prophesee sensors!
 
 
 ## License


### PR DESCRIPTION
The SilkyEVCam patch [disables the EVK4 cameras](https://github.com/ros-event-camera/metavision_driver/issues/56)!
